### PR TITLE
Various fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     "wpackagist-plugin/ultimate-member": "^2.1.2",
     "wpackagist-plugin/um-recaptcha": "^2.1.4",
     "wpackagist-plugin/wp-mail-smtp": "^2.0.1",
-    "wpackagist-plugin/wp-native-php-sessions": "^1.0.0"
+    "wpackagist-plugin/wp-native-php-sessions": "^1.0.0",
+    "wpackagist-plugin/wp-youtube-lyte": "^1.7"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cncf/wp-mu-plugins.git",
-                "reference": "904920eba4e808013dc5d6879ebe2a26869460e6"
+                "reference": "4a537c4dd9fc46abf066b8a515847bb6eab33c61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/904920eba4e808013dc5d6879ebe2a26869460e6",
-                "reference": "904920eba4e808013dc5d6879ebe2a26869460e6",
+                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/4a537c4dd9fc46abf066b8a515847bb6eab33c61",
+                "reference": "4a537c4dd9fc46abf066b8a515847bb6eab33c61",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
                 "source": "https://github.com/cncf/wp-mu-plugins/tree/master",
                 "issues": "https://github.com/cncf/wp-mu-plugins/issues"
             },
-            "time": "2020-09-09T22:37:38+00:00"
+            "time": "2020-09-10T23:12:41+00:00"
         },
         {
             "name": "composer/installers",
@@ -810,15 +810,15 @@
         },
         {
             "name": "wpackagist-plugin/ultimate-member",
-            "version": "2.1.8",
+            "version": "2.1.9",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ultimate-member/",
-                "reference": "tags/2.1.8"
+                "reference": "tags/2.1.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ultimate-member.2.1.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/ultimate-member.2.1.9.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cncf/wp-mu-plugins.git",
-                "reference": "ee021cae05a55c1226d18000ec4947864333ca01"
+                "reference": "9ec8967607e77d81737f278459a6cd4ed10d6dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/ee021cae05a55c1226d18000ec4947864333ca01",
-                "reference": "ee021cae05a55c1226d18000ec4947864333ca01",
+                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/9ec8967607e77d81737f278459a6cd4ed10d6dbb",
+                "reference": "9ec8967607e77d81737f278459a6cd4ed10d6dbb",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
                 "source": "https://github.com/cncf/wp-mu-plugins/tree/master",
                 "issues": "https://github.com/cncf/wp-mu-plugins/issues"
             },
-            "time": "2020-09-02T02:57:59+00:00"
+            "time": "2020-09-09T21:29:53+00:00"
         },
         {
             "name": "composer/installers",
@@ -163,16 +163,16 @@
         },
         {
             "name": "humanmade/publication-checklist",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/publication-checklist.git",
-                "reference": "29482bb6cca7893bda2bc6480a323c2920238e03"
+                "reference": "f82cb5933595502a0b7a004a758778d6b510c409"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/29482bb6cca7893bda2bc6480a323c2920238e03",
-                "reference": "29482bb6cca7893bda2bc6480a323c2920238e03",
+                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/f82cb5933595502a0b7a004a758778d6b510c409",
+                "reference": "f82cb5933595502a0b7a004a758778d6b510c409",
                 "shasum": ""
             },
             "require": {
@@ -190,7 +190,7 @@
                 }
             ],
             "description": "Run checks and enforce conditions before posts are published.",
-            "time": "2020-08-11T10:02:20+00:00"
+            "time": "2020-09-08T16:13:47+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -1336,5 +1336,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cncf/wp-mu-plugins.git",
-                "reference": "ed1c60d4a60aa14575c9312c0072dcf926e64b08"
+                "reference": "904920eba4e808013dc5d6879ebe2a26869460e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/ed1c60d4a60aa14575c9312c0072dcf926e64b08",
-                "reference": "ed1c60d4a60aa14575c9312c0072dcf926e64b08",
+                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/904920eba4e808013dc5d6879ebe2a26869460e6",
+                "reference": "904920eba4e808013dc5d6879ebe2a26869460e6",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
                 "source": "https://github.com/cncf/wp-mu-plugins/tree/master",
                 "issues": "https://github.com/cncf/wp-mu-plugins/issues"
             },
-            "time": "2020-09-09T21:46:06+00:00"
+            "time": "2020-09-09T22:37:38+00:00"
         },
         {
             "name": "composer/installers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52fe1a1c04a6306e234a0deafbed2f7d",
+    "content-hash": "a60d4418436ddcc776a43d929b798978",
     "packages": [
         {
             "name": "cncf/wp-mu-plugins",
@@ -352,16 +352,6 @@
                 "php",
                 "type"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-07-20T17:29:33+00:00"
         },
         {
@@ -518,20 +508,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -903,6 +879,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-native-php-sessions/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-youtube-lyte",
+            "version": "1.7.13",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-youtube-lyte/",
+                "reference": "tags/1.7.13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-youtube-lyte.1.7.13.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-youtube-lyte/"
         }
     ],
     "packages-dev": [
@@ -1192,16 +1186,6 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "funding": [
-                {
-                    "url": "https://github.com/Ocramius",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-09-02T19:02:24+00:00"
         },
         {
@@ -1352,6 +1336,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cncf/wp-mu-plugins.git",
-                "reference": "9ec8967607e77d81737f278459a6cd4ed10d6dbb"
+                "reference": "ed1c60d4a60aa14575c9312c0072dcf926e64b08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/9ec8967607e77d81737f278459a6cd4ed10d6dbb",
-                "reference": "9ec8967607e77d81737f278459a6cd4ed10d6dbb",
+                "url": "https://api.github.com/repos/cncf/wp-mu-plugins/zipball/ed1c60d4a60aa14575c9312c0072dcf926e64b08",
+                "reference": "ed1c60d4a60aa14575c9312c0072dcf926e64b08",
                 "shasum": ""
             },
             "require": {
@@ -32,7 +32,7 @@
                 "source": "https://github.com/cncf/wp-mu-plugins/tree/master",
                 "issues": "https://github.com/cncf/wp-mu-plugins/issues"
             },
-            "time": "2020-09-09T21:29:53+00:00"
+            "time": "2020-09-09T21:46:06+00:00"
         },
         {
             "name": "composer/installers",

--- a/web/wp-content/themes/lf-theme/components/pagination.php
+++ b/web/wp-content/themes/lf-theme/components/pagination.php
@@ -36,7 +36,7 @@ if ( strpos( $posts_pagination, 'prev page-numbers' ) === false ) {
 
 // If no next page link, append a placeholder with `visibility: hidden` to take its place.
 if ( strpos( $posts_pagination, 'next page-numbers' ) === false ) {
-	$posts_pagination = str_replace( '</div>', '<span class="next page-numbers placeholder" aria-hidden="true">' . $next_text . '</span></div>', $posts_pagination );
+	$posts_pagination = str_replace( '</div>', '<span class="next page-numbers assistive-text" aria-hidden="true">' . $next_text . '</span></div>', $posts_pagination );
 }
 
 if ( $posts_pagination ) :

--- a/web/wp-content/themes/lf-theme/includes/gutenberg-options.php
+++ b/web/wp-content/themes/lf-theme/includes/gutenberg-options.php
@@ -13,15 +13,15 @@
   * Block Template - Page
   */
 function lf_page_block_template() {
-
-	$page_type_object = get_post_type_object( 'page' );
-
+	$page_type_object           = get_post_type_object( 'page' );
 	$page_type_object->template = array(
 		array(
 			'core/paragraph',
 			array(
-				'placeholder'   => 'This first introductory paragraph of text should be H3 size lorem ipsum dolor sit amet consectetuer adipiscing elit aenean commodo',
-				'className' => 'has-header-3-font-size is-style-max-900',
+				'placeholder' => 'This first introductory paragraph of text should be H3 size lorem ipsum dolor sit amet consectetuer adipiscing elit aenean commodo',
+				'className'   => 'is-style-max-width-900',
+				'fontSize'   => 'header-3',
+
 			),
 		),
 		array(
@@ -30,8 +30,6 @@ function lf_page_block_template() {
 				'placeholder' => 'And then change to normal paragraph text lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula get dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate get, arcu. In enim justo, rhoncus ut imperdiet a.',
 			),
 		),
-
 	);
-
 }
 add_action( 'init', 'lf_page_block_template' );

--- a/web/wp-content/themes/lf-theme/includes/image-sizes.php
+++ b/web/wp-content/themes/lf-theme/includes/image-sizes.php
@@ -51,7 +51,7 @@ add_image_size( 'hero-320', 320, 220, true );
 
 // Image Hero Block.
 add_image_size( 'ihero-1400', 1400, 400, true );
-add_image_size( 'ihero-2800', 2800, 800, true );
+add_image_size( 'ihero-2800', 2048, 585, true );
 
 // people.
 add_image_size( 'people-250', 250, 250, true );

--- a/web/wp-content/themes/lf-theme/includes/image-sizes.php
+++ b/web/wp-content/themes/lf-theme/includes/image-sizes.php
@@ -51,6 +51,7 @@ add_image_size( 'hero-320', 320, 220, true );
 
 // Image Hero Block.
 add_image_size( 'ihero-1400', 1400, 400, true );
+add_image_size( 'ihero-2800', 2800, 800, true );
 
 // people.
 add_image_size( 'people-250', 250, 250, true );

--- a/web/wp-content/themes/lf-theme/includes/image-sizes.php
+++ b/web/wp-content/themes/lf-theme/includes/image-sizes.php
@@ -51,7 +51,7 @@ add_image_size( 'hero-320', 320, 220, true );
 
 // Image Hero Block.
 add_image_size( 'ihero-1400', 1400, 400, true );
-add_image_size( 'ihero-2800', 2048, 585, true );
+add_image_size( 'ihero-2048', 2048, 585, true );
 
 // people.
 add_image_size( 'people-250', 250, 250, true );

--- a/web/wp-content/themes/lf-theme/source/scss/annual-report-2018.scss
+++ b/web/wp-content/themes/lf-theme/source/scss/annual-report-2018.scss
@@ -587,27 +587,6 @@ div.row .col.section-title {
     justify-content: space-between
 }
 
-.past-date {
-    color: #476069;
-    /* font-size: 14px; */
-    padding: 0 0 0 13px;
-    position: relative
-}
-
-.past-date:before {
-    content: '';
-    background: url('/wp-content/themes/lf-theme/images/annual-reports/2018/icon-calendar.svg');
-    position: absolute;
-    left: 0;
-    top: 50%;
-    width: 9px;
-    height: 9px;
-    background-size: contain;
-    background-repeat: no-repeat;
-    -webkit-transform: translateY(-50%);
-    transform: translateY(-50%)
-}
-
 .home-sub-head {
     font-size: 23px;
     color: #47529e;

--- a/web/wp-content/themes/lf-theme/source/scss/components/_archive.scss
+++ b/web/wp-content/themes/lf-theme/source/scss/components/_archive.scss
@@ -174,6 +174,14 @@
     }
 }
 
+.archive-excerpt {
+    font-size: 0.85em;
+}
+
+.featured .archive-excerpt {
+    font-size: initial;
+}
+
 // In the News only.
 .in-news-item {
 

--- a/web/wp-content/themes/lf-theme/source/scss/core/_entry-content.scss
+++ b/web/wp-content/themes/lf-theme/source/scss/core/_entry-content.scss
@@ -217,5 +217,23 @@
         ol {
             max-width: 700px;
         }
+
+        a {
+            /* These are technically the same, but use both */
+            overflow-wrap: break-word;
+            word-wrap: break-word;
+
+            -ms-word-break: break-all;
+            /* This is the dangerous one in WebKit, as it breaks things wherever */
+            word-break: break-all;
+            /* Instead use this non-standard one: */
+            word-break: break-word;
+
+            /* Adds a hyphen where the word breaks, if supported (No Blink) */
+            -ms-hyphens: auto;
+            -moz-hyphens: auto;
+            -webkit-hyphens: auto;
+            hyphens: auto;
+        }
     }
 }


### PR DESCRIPTION
Fix: Stop links pushing out page boundaries, closes #312
Fix: Adding default typography size properly via fontSize, closes #315
Fix: Removing Next from pagination when no more pages, closes #318
Fix: Reducing font size of excerpt on archive, fixes #321
Fix 404 issue in annual report 2018, ref #295 
Updating composer - LF MU - pre-publish checklist changes, ref #263, and installing WP YouTube Lyte and updating other plugins, ref #311

