### PR TITLE
Automate metric retreival

### DIFF
--- a/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
+++ b/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
@@ -480,7 +480,7 @@ class Lf_Utils {
 	}
 
 	/**
-	 * Retrieve homepage metrics from devstats and LFX.
+	 * Retrieve metrics for Who We Are page block.
 	 */
 	public static function get_whoweare_metrics() {
 		$metrics = get_transient( 'cncf_whoweare_metrics' );

--- a/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
+++ b/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
@@ -448,7 +448,7 @@ class Lf_Utils {
 	public static function get_homepage_metrics() {
 		$metrics = get_transient( 'cncf_homepage_metrics' );
 
-		if ( false !== $metrics ) {
+		if ( false === $metrics ) {
 			$data = wp_remote_post(
 				'https://devstats.cncf.io/api/v1',
 				array(
@@ -479,5 +479,17 @@ class Lf_Utils {
 		return $metrics;
 	}
 
+	/**
+	 * Retrieve homepage metrics from devstats and LFX.
+	 */
+	public static function get_whoweare_metrics() {
+		$metrics = get_transient( 'cncf_whoweare_metrics' );
 
+		if ( false === $metrics ) {
+			$metrics = LF_Utils::get_homepage_metrics();
+
+			set_transient( 'cncf_whoweare_metrics', $metrics, DAY_IN_SECONDS );
+		}
+		return $metrics;
+	}
 }

--- a/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
+++ b/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
@@ -488,6 +488,18 @@ class Lf_Utils {
 		if ( false === $metrics ) {
 			$metrics = LF_Utils::get_homepage_metrics();
 
+			$data = wp_remote_get( 'https://landscape.cncf.io/data/exports/certified-kubernetes.json' );
+			$remote_body = json_decode( wp_remote_retrieve_body( $data ) );
+			$metrics['certified-kubernetes'] = count( $remote_body );
+
+			$data = wp_remote_get( 'https://landscape.cncf.io/data/exports/cncf-members.json' );
+			$remote_body = json_decode( wp_remote_retrieve_body( $data ) );
+			$metrics['cncf-members'] = count( $remote_body );
+
+			// in case any of the above fails, use reasonable alternatives.
+			$metrics['certified-kubernetes'] = max( $metrics['certified-kubernetes'], 103 );
+			$metrics['cncf-members'] = max( $metrics['cncf-members'], 630 );
+
 			set_transient( 'cncf_whoweare_metrics', $metrics, DAY_IN_SECONDS );
 		}
 		return $metrics;

--- a/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
+++ b/web/wp-content/themes/lf-theme/classes/class-lf-utils.php
@@ -442,4 +442,28 @@ class Lf_Utils {
 		}
 	}
 
+	/**
+	 * Retrieve homepage metrics from devstats.
+	 */
+	public static function get_homepage_metrics() {
+		$metrics = get_transient( 'cncf_homepage_metrics' );
+
+		if ( false === $metrics ) {
+			$data = wp_remote_post(
+				'https://devstats.cncf.io/api/v1',
+				array(
+					'headers'     => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+					'body'        => '{"api":"SiteStats","payload":{"project":"all"}}',
+					'method'      => 'POST',
+					'data_format' => 'body',
+				)
+			);
+
+			$metrics = wp_remote_retrieve_body( $data );
+			set_transient( 'cncf_homepage_metrics', $metrics, DAY_IN_SECONDS );
+		}
+		return $metrics;
+	}
+
+
 }

--- a/web/wp-content/themes/lf-theme/components/wip/home-hero.php
+++ b/web/wp-content/themes/lf-theme/components/wip/home-hero.php
@@ -7,6 +7,35 @@
  * @since 1.0.0
  */
 
+
+/**
+ * Retrieve posts from another blog and cache the response body.
+ *
+ * @return string Body of the response. Empty string if no body or incorrect parameter given.
+ */
+function prefix_get_posts_from_other_blog() {
+	$metrics = get_transient( 'cncf_homepage_metrics' );
+
+	if ( false === $metrics ) {
+
+		$data = wp_remote_post(
+			'https://devstats.cncf.io/api/v1',
+			array(
+				'headers'     => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+				'body'        => '{"api": "ListProjects"}',
+				'method'      => 'POST',
+				'data_format' => 'body',
+			)
+		);
+
+		$metrics = wp_remote_retrieve_body( $data );
+
+		set_transient( 'cncf_homepage_metrics', $metrics, DAY_IN_SECONDS );
+	}
+	return $metrics;
+}
+var_dump(json_decode( prefix_get_posts_from_other_blog()));
+
 ?>
 
 <section class="home-hero">

--- a/web/wp-content/themes/lf-theme/components/wip/home-hero.php
+++ b/web/wp-content/themes/lf-theme/components/wip/home-hero.php
@@ -7,8 +7,7 @@
  * @since 1.0.0
  */
 
-var_dump(json_decode( LF_Utils::get_homepage_metrics()));
-
+$metrics = LF_Utils::get_homepage_metrics();
 ?>
 
 <section class="home-hero">
@@ -19,9 +18,9 @@ var_dump(json_decode( LF_Utils::get_homepage_metrics()));
 	<h1>Building sustainable ecosystems for cloud native software
 	</h1>
 	<ul class="data-display no-style h4">
-		<li><span>112K+</span> Contributors</li>
-		<li><span>2M+</span> Contributions</li>
-		<li><span>261M+</span> Lines of Code</li>
+		<li><span><?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>K+</span> Contributors</li>
+		<li><span><?php echo esc_html( round( $metrics['contributions'] / 1000000, 1 ) ); ?>M+</span> Contributions</li>
+		<li><span><?php echo esc_html( round( $metrics['linesofcode'] / 1000000, 1 ) ); ?>M+</span> Lines of Code</li>
 	</ul>
 	<p class="h4 fw-400">
 		Cloud Native Computing Foundation (CNCF) serves as the vendor-neutral home for many of the fastest-growing open source projects, including <br/>

--- a/web/wp-content/themes/lf-theme/components/wip/home-hero.php
+++ b/web/wp-content/themes/lf-theme/components/wip/home-hero.php
@@ -7,34 +7,7 @@
  * @since 1.0.0
  */
 
-
-/**
- * Retrieve posts from another blog and cache the response body.
- *
- * @return string Body of the response. Empty string if no body or incorrect parameter given.
- */
-function prefix_get_posts_from_other_blog() {
-	$metrics = get_transient( 'cncf_homepage_metrics' );
-
-	if ( false === $metrics ) {
-
-		$data = wp_remote_post(
-			'https://devstats.cncf.io/api/v1',
-			array(
-				'headers'     => array( 'Content-Type' => 'application/json; charset=utf-8' ),
-				'body'        => '{"api": "ListProjects"}',
-				'method'      => 'POST',
-				'data_format' => 'body',
-			)
-		);
-
-		$metrics = wp_remote_retrieve_body( $data );
-
-		set_transient( 'cncf_homepage_metrics', $metrics, DAY_IN_SECONDS );
-	}
-	return $metrics;
-}
-var_dump(json_decode( prefix_get_posts_from_other_blog()));
+var_dump(json_decode( LF_Utils::get_homepage_metrics()));
 
 ?>
 

--- a/web/wp-content/themes/lf-theme/components/wip/home-hosted-projects.php
+++ b/web/wp-content/themes/lf-theme/components/wip/home-hosted-projects.php
@@ -56,27 +56,21 @@
 <li><a href="/projects/">
 <span
 data-purecounter-end="<?php echo esc_html( $graduated_count ); ?>"
-data-purecounter-duration="400"
 data-purecounter-delay="50"
-data-purecounter-once="false"
 class="purecounter"><?php echo esc_html( $graduated_count ); ?></span>
 		Graduated Projects
 	</a></li>
 <li><a href="/projects/#incubating">
 <span
 data-purecounter-end="<?php echo esc_html( $incubating_count ); ?>"
-data-purecounter-duration="150"
 data-purecounter-delay="50"
-data-purecounter-once="false"
 class="purecounter"><?php echo esc_html( $incubating_count ); ?></span>
 		Incubating Projects
 	</a></li>
 <li><a href="/sandbox-projects/">
 <span
 data-purecounter-end="<?php echo esc_html( $sandbox_count ); ?>"
-data-purecounter-duration="125"
 data-purecounter-delay="25"
-data-purecounter-once="false"
 class="purecounter"><?php echo esc_html( $sandbox_count ); ?></span>
 		Sandbox Projects
 	</a></li>

--- a/web/wp-content/themes/lf-theme/functions.php
+++ b/web/wp-content/themes/lf-theme/functions.php
@@ -87,6 +87,9 @@ require_once 'includes/shortcode-people.php';
 // projects shortcode.
 require_once 'includes/shortcode-projects.php';
 
+// who we are metrics shortcode.
+require_once 'includes/shortcode-whoweare-metrics.php';
+
 // kubeweeklys shortcodes.
 require_once 'includes/shortcode-kubeweeklys.php';
 require_once 'includes/shortcode-kubeweekly-newsletter.php';

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -30,8 +30,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>"
-						data-purecounter-duration="1"
-						data-purecounter-delay="10"
+						data-purecounter-delay="20"
 						class="purecounter">
 						<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>
 					</span>K+
@@ -49,8 +48,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="<?php echo esc_html( $metrics['cncf-members'] ); ?>"
-						data-purecounter-duration="1"
-						data-purecounter-delay="10"
+						data-purecounter-delay="20"
 						class="purecounter">
 						<?php echo esc_html( $metrics['cncf-members'] ); ?>
 					</span>
@@ -67,8 +65,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="<?php echo esc_html( $metrics['certified-kubernetes'] ); ?>"
-						data-purecounter-duration="1"
-						data-purecounter-delay="10"
+						data-purecounter-delay="20"
 						class="purecounter">
 						<?php echo esc_html( $metrics['certified-kubernetes'] ); ?>
 					</span>
@@ -85,8 +82,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="163"
-						data-purecounter-duration="1"
-						data-purecounter-delay="10"
+						data-purecounter-delay="20"
 						class="purecounter">
 						163
 					</span>K+

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -41,7 +41,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 		</div>
 
 		<div class="count-up-column">
-			<a class="no-decoration" href="/certification/training/">
+			<a class="no-decoration" href="/about/members/">
 				<div class="icon-wrap">
 					<img src="/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">
 				</div>

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -13,6 +13,9 @@
   * @param array $atts Attributes.
   */
 function add_whoweare_metrics_shortcode( $atts ) {
+	// purecounter countup.
+	wp_enqueue_script( 'purecounter', get_template_directory_uri() . '/source/js/third-party/purecounter_vanilla.js', array(), filemtime( get_template_directory() . '/source/js/third-party/purecounter_vanilla.js' ), false );
+
 	$metrics = LF_Utils::get_whoweare_metrics();
 
 	ob_start();
@@ -25,7 +28,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2"><?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>K+</div>
+					<div class="number number-item h2">
+					<span data-purecounter-end="<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>"
+						data-purecounter-duration="1"
+						data-purecounter-delay="10"
+						class="purecounter">
+						<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>
+					</span>K+
+					</div>
 					<span class="count-up-description"># of contributors to CNCF projects</span>
 				</div>
 			</a>
@@ -37,7 +47,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2">633+</div>
+					<div class="number number-item h2">
+					<span data-purecounter-end="<?php echo esc_html( $metrics['cncf-members'] ); ?>"
+						data-purecounter-duration="1"
+						data-purecounter-delay="10"
+						class="purecounter">
+						<?php echo esc_html( $metrics['cncf-members'] ); ?>
+					</span>
+					</div>
 					<span class="count-up-description">CNCF Members</span>
 				</div>
 			</a>
@@ -48,7 +65,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2">104+</div>
+					<div class="number number-item h2">
+					<span data-purecounter-end="<?php echo esc_html( $metrics['certified-kubernetes'] ); ?>"
+						data-purecounter-duration="1"
+						data-purecounter-delay="10"
+						class="purecounter">
+						<?php echo esc_html( $metrics['certified-kubernetes'] ); ?>
+					</span>
+					</div>
 					<span class="count-up-description">Certified Kubernetes Distributions &amp; Platforms</span>
 				</div>
 			</a>
@@ -59,7 +83,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2">163K+</div>
+					<div class="number number-item h2">
+					<span data-purecounter-end="163"
+						data-purecounter-duration="1"
+						data-purecounter-delay="10"
+						class="purecounter">
+						163
+					</span>K+
+					</div>
 					<span class="count-up-description">CNCF Meetup members</span>
 				</div>
 			</a>

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -19,53 +19,52 @@ function add_whoweare_metrics_shortcode( $atts ) {
 	?>
 <section data-element="count-up-block" class="count-up-block" style="--text-main-color: #FFFFFF;">
 	<div class="count-up-wrapper">
-				<div class="count-up-column">
-					<a class="no-decoration" target="_blank" rel="noopener" href="https://all.devstats.cncf.io/">
-				
-						<div class="icon-wrap">
-							<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
-						</div>
-						<div class="text-wrap" data-mh="facts-text-wrap">
-							<div class="number number-item h2"><?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>K+</div>
-							<span class="count-up-description"># of contributors to CNCF projects</span>
-						</div>
-					</a>
+		<div class="count-up-column">
+			<a class="no-decoration" target="_blank" rel="noopener" href="https://all.devstats.cncf.io/">		
+				<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
 				</div>
+				<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2"><?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>K+</div>
+					<span class="count-up-description"># of contributors to CNCF projects</span>
+				</div>
+			</a>
+		</div>
 
-				<div class="count-up-column">
-						<a class="no-decoration" href="https://www.cncf.io/certification/training/">
-				
-								<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">				</div>
-								<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2">633</div>
-										<span class="count-up-description">CNCF Members</span>
-										</div>
-							</a>
-							</div>
-				<div class="count-up-column">
-						<a class="no-decoration" href="https://www.cncf.io/certification/software-conformance/">
-				
-								<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">				</div>
-								<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2">104</div>
-										<span class="count-up-description">Certified Kubernetes Distributions &amp; Platforms</span>
-										</div>
-							</a>
-							</div>
-				<div class="count-up-column">
-						<a class="no-decoration" target="_blank" rel="noopener" href="https://www.meetup.com/pro/cncf/">
-				
-								<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">				</div>
-								<div class="text-wrap" data-mh="facts-text-wrap">
+		<div class="count-up-column">
+			<a class="no-decoration" href="https://www.cncf.io/certification/training/">		
+				<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">
+				</div>
+				<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2">633+</div>
+					<span class="count-up-description">CNCF Members</span>
+				</div>
+			</a>
+		</div>
+		<div class="count-up-column">
+			<a class="no-decoration" href="https://www.cncf.io/certification/software-conformance/">				
+				<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">
+				</div>
+				<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2">104+</div>
+					<span class="count-up-description">Certified Kubernetes Distributions &amp; Platforms</span>
+				</div>
+			</a>
+		</div>
+		<div class="count-up-column">
+			<a class="no-decoration" target="_blank" rel="noopener" href="https://www.meetup.com/pro/cncf/">				
+				<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">
+				</div>
+				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">163K+</div>
-										<span class="count-up-description">CNCF Meetup members</span>
-										</div>
-							</a>
-							</div>
-			</div>
+					<span class="count-up-description">CNCF Meetup members</span>
+				</div>
+			</a>
+		</div>
+	</div>
 </section>
 	<?php
 	$block_content = ob_get_clean();

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -38,7 +38,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 								<div class="icon-wrap">
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">				</div>
 								<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2" data-element="lf-number" data-original="633" data-to="633" data-speed="4000">633</div>
+					<div class="number number-item h2">633</div>
 										<span class="count-up-description">CNCF Members</span>
 										</div>
 							</a>
@@ -49,7 +49,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 								<div class="icon-wrap">
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">				</div>
 								<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2" data-element="lf-number" data-original="104" data-to="104" data-speed="4000">104</div>
+					<div class="number number-item h2">104</div>
 										<span class="count-up-description">Certified Kubernetes Distributions &amp; Platforms</span>
 										</div>
 							</a>
@@ -60,7 +60,7 @@ function add_whoweare_metrics_shortcode( $atts ) {
 								<div class="icon-wrap">
 					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">				</div>
 								<div class="text-wrap" data-mh="facts-text-wrap">
-					<div class="number number-item h2" data-element="lf-number" data-original="159027" data-to="159027" data-speed="4000">159,027</div>
+					<div class="number number-item h2">163K+</div>
 										<span class="count-up-description">CNCF Meetup members</span>
 										</div>
 							</a>

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -23,14 +23,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 <section data-element="count-up-block" class="count-up-block" style="--text-main-color: #FFFFFF;">
 	<div class="count-up-wrapper">
 		<div class="count-up-column">
-			<a class="no-decoration" target="_blank" rel="noopener" href="https://all.devstats.cncf.io/">		
+			<a class="no-decoration" target="_blank" rel="noopener" href="https://all.devstats.cncf.io/">
 				<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
+					<img src="/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>"
-						data-purecounter-delay="20"
+						data-purecounter-delay="15"
 						class="purecounter">
 						<?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>
 					</span>K+
@@ -41,9 +41,9 @@ function add_whoweare_metrics_shortcode( $atts ) {
 		</div>
 
 		<div class="count-up-column">
-			<a class="no-decoration" href="https://www.cncf.io/certification/training/">		
+			<a class="no-decoration" href="/certification/training/">
 				<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">
+					<img src="/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
@@ -58,9 +58,9 @@ function add_whoweare_metrics_shortcode( $atts ) {
 			</a>
 		</div>
 		<div class="count-up-column">
-			<a class="no-decoration" href="https://www.cncf.io/certification/software-conformance/">				
+			<a class="no-decoration" href="/certification/software-conformance/">
 				<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">
+					<img src="/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
@@ -75,14 +75,14 @@ function add_whoweare_metrics_shortcode( $atts ) {
 			</a>
 		</div>
 		<div class="count-up-column">
-			<a class="no-decoration" target="_blank" rel="noopener" href="https://www.meetup.com/pro/cncf/">				
+			<a class="no-decoration" target="_blank" rel="noopener" href="https://www.meetup.com/pro/cncf/">
 				<div class="icon-wrap">
-					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">
+					<img src="/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">
 				</div>
 				<div class="text-wrap" data-mh="facts-text-wrap">
 					<div class="number number-item h2">
 					<span data-purecounter-end="163"
-						data-purecounter-delay="20"
+						data-purecounter-delay="10"
 						class="purecounter">
 						163
 					</span>K+

--- a/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
+++ b/web/wp-content/themes/lf-theme/includes/shortcode-whoweare-metrics.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Who We Are Metrics Shortcode
+ *
+ * @package WordPress
+ * @subpackage lf-theme
+ * @since 1.0.0
+ */
+
+ /**
+  * Add Kubeweekly Newsletter shortcode.
+  *
+  * @param array $atts Attributes.
+  */
+function add_whoweare_metrics_shortcode( $atts ) {
+	$metrics = LF_Utils::get_whoweare_metrics();
+
+	ob_start();
+	?>
+<section data-element="count-up-block" class="count-up-block" style="--text-main-color: #FFFFFF;">
+	<div class="count-up-wrapper">
+				<div class="count-up-column">
+					<a class="no-decoration" target="_blank" rel="noopener" href="https://all.devstats.cncf.io/">
+				
+						<div class="icon-wrap">
+							<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-computer.svg" class="attachment-medium size-medium" alt="Computer" loading="lazy" height="74.18562" width="118.40117">
+						</div>
+						<div class="text-wrap" data-mh="facts-text-wrap">
+							<div class="number number-item h2"><?php echo esc_html( round( $metrics['contributors'] / 1000 ) ); ?>K+</div>
+							<span class="count-up-description"># of contributors to CNCF projects</span>
+						</div>
+					</a>
+				</div>
+
+				<div class="count-up-column">
+						<a class="no-decoration" href="https://www.cncf.io/certification/training/">
+				
+								<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-rocket.svg" class="attachment-medium size-medium" alt="Rocket" loading="lazy" height="92.41077" width="92.41107">				</div>
+								<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2" data-element="lf-number" data-original="633" data-to="633" data-speed="4000">633</div>
+										<span class="count-up-description">CNCF Members</span>
+										</div>
+							</a>
+							</div>
+				<div class="count-up-column">
+						<a class="no-decoration" href="https://www.cncf.io/certification/software-conformance/">
+				
+								<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-settings.svg" class="attachment-medium size-medium" alt="Settings" loading="lazy" height="94.09873" width="110.60081">				</div>
+								<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2" data-element="lf-number" data-original="104" data-to="104" data-speed="4000">104</div>
+										<span class="count-up-description">Certified Kubernetes Distributions &amp; Platforms</span>
+										</div>
+							</a>
+							</div>
+				<div class="count-up-column">
+						<a class="no-decoration" target="_blank" rel="noopener" href="https://www.meetup.com/pro/cncf/">
+				
+								<div class="icon-wrap">
+					<img src="https://www.cncf.io/wp-content/uploads/2020/05/icon-members.svg" class="attachment-medium size-medium" alt="Users" loading="lazy" height="106.10079" width="140.8399">				</div>
+								<div class="text-wrap" data-mh="facts-text-wrap">
+					<div class="number number-item h2" data-element="lf-number" data-original="159027" data-to="159027" data-speed="4000">159,027</div>
+										<span class="count-up-description">CNCF Meetup members</span>
+										</div>
+							</a>
+							</div>
+			</div>
+</section>
+	<?php
+	$block_content = ob_get_clean();
+	return $block_content;
+}
+add_shortcode( 'whoweare-metrics', 'add_whoweare_metrics_shortcode' );


### PR DESCRIPTION
This PR automates retrieval of the metrics on the [homepage](https://pr-406-cncfci.pantheonsite.io/) and [who we are](https://pr-406-cncfci.pantheonsite.io/about/who-we-are/) pages.  The only metric I can't seem to pull in automatically is the number of Meetup members, however, that number may go away soon as we've moved to Bevy.  

I've re-used the purecounter library to count up the who we are metrics as that's what was also used on the homepage.  The number for CNCF members and Certified platforms are wrong right now and the landscape people need to fix.

Related issues:
- https://github.com/cncf/cncf.io/issues/405
- https://github.com/cncf/cncf.io/issues/403