### PR TITLE
Turn off wechat modal to fix code block highlights

### DIFF
--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -208,7 +208,7 @@ class Lf_Mu_Admin {
 
 		$options['social_youtube'] = ( isset( $input['social_youtube'] ) && ! empty( $input['social_youtube'] ) ) ? esc_url( $input['social_youtube'] ) : '';
 
-		$options['social_wechat_id'] = ( isset( $input['social_wechat_id'] ) && ! empty( $input['social_wechat_id'] ) ) ? absint( $input['social_wechat_id'] ) : '';
+		$options['social_wechat'] = ( isset( $input['social_wechat'] ) && ! empty( $input['social_wechat'] ) ) ? absint( $input['social_wechat'] ) : '';
 
 		$options['generic_thumb_id'] = ( isset( $input['generic_thumb_id'] ) && ! empty( $input['generic_thumb_id'] ) ) ? absint( $input['generic_thumb_id'] ) : '';
 

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
@@ -80,7 +80,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 		$social_youtube = ( isset( $options['social_youtube'] ) && ! empty( $options['social_youtube'] ) ) ? esc_attr( $options['social_youtube'] ) : '';
 
-		$social_wechat_id = ( isset( $options['social_wechat_id'] ) && ! empty( $options['social_wechat_id'] ) ) ? absint( $options['social_wechat_id'] ) : '';
+		$social_wechat = ( isset( $options['social_wechat'] ) && ! empty( $options['social_wechat'] ) ) ? absint( $options['social_wechat'] ) : '';
 
 		$generic_thumb_id = ( isset( $options['generic_thumb_id'] ) && ! empty( $options['generic_thumb_id'] ) ) ? absint( $options['generic_thumb_id'] ) : '';
 
@@ -521,27 +521,14 @@ if ( ! defined( 'WPINC' ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="social_wechat_id">WeChat</label>
+					<th scope="row"><label for="social_wechat">WeChat</label>
 					</th>
 					<td>
-						<div class='image-preview-wrapper'>
-							<img src='<?php echo esc_url( wp_get_attachment_url( $social_wechat_id ) ); ?>'
-								class="image-preview thumbnail-margin-bottom"
-								data-id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat_id">
-						</div>
-						<input type="button"
-							data-id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat_id"
-							class="upload_image_button button"
-							value="Choose image" />
-						<input type="button"
-							data-id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat_id"
-							class="clear_upload_image_button button"
-							value="Remove image" />
-						<input type="hidden"
-							id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat_id"
-							data-id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat_id"
-							name="<?php echo esc_html( $this->plugin_name ); ?>[social_wechat_id]"
-							value="<?php echo absint( $social_wechat_id ); ?>" />
+						<input type="text" class="social_wechat regular-text"
+							id="<?php echo esc_html( $this->plugin_name ); ?>-social_wechat"
+							name="<?php echo esc_html( $this->plugin_name ); ?>[social_wechat]"
+							value="<?php echo esc_url( $social_wechat ); ?>"
+							placeholder="https://www.cncf.io/wechat" />
 					</td>
 				</tr>
 			</tbody>

--- a/web/wp-content/themes/cncf-twenty-two/components/social-links.php
+++ b/web/wp-content/themes/cncf-twenty-two/components/social-links.php
@@ -29,10 +29,9 @@ $site_options = get_option( 'lf-mu' );
 			href="<?php echo esc_url( $site_options['social_linkedin'] ); ?>"><?php LF_Utils::get_svg( 'social/linkedin-black.svg' ); ?></a></li>
 	<?php endif; ?>
 
-	<?php if ( isset( $site_options['social_wechat_id'] ) && $site_options['social_wechat_id'] ) : ?>
-	<li class="social-wechat_id"><button class="js-modal button-reset"
-	data-modal-prefix-class="generic"
-	data-modal-content-id="modal-wechat" title="<?php echo esc_html( get_bloginfo( 'name' ) ) . ' on WeChat'; ?>"><?php LF_Utils::get_svg( 'social/wechat.svg' ); ?></button></li>
+	<?php if ( isset( $site_options['social_wechat'] ) && $site_options['social_wechat'] ) : ?>
+	<li class="social-wechat"><a title="<?php echo esc_html( get_bloginfo( 'name' ) ) . ' on WeChat'; ?>"
+			href="<?php echo esc_url( $site_options['social_wechat'] ); ?>"><?php LF_Utils::get_svg( 'social/wechat.svg' ); ?></a></li>
 	<?php endif; ?>
 
 	<?php if ( isset( $site_options['social_youtube'] ) && $site_options['social_youtube'] ) : ?>
@@ -65,18 +64,3 @@ $site_options = get_option( 'lf-mu' );
 			href="<?php echo esc_url( $site_options['social_slack'] ); ?>"><?php LF_Utils::get_svg( 'social/slack.svg' ); ?></a></li>
 	<?php endif; ?>
 </ul>
-
-<?php
-// Include WeChat Modal only when WeChat Social is activated.
-if ( isset( $site_options['social_wechat_id'] ) ) :
-	// Modal.
-	?>
-	<div class="modal-hide" id="modal-wechat" aria-hidden="true">
-			<div class="modal-content-wrapper">
-				<div class="modal__content"
-					id="modal-wechat-content">
-					<img alt="CNCF on WeChat" loading="lazy" src="<?php echo esc_url( wp_get_attachment_url( $site_options['social_wechat_id'] ) ); ?>">
-				</div>
-			</div>
-		</div>
-	<?php endif; ?>

--- a/web/wp-content/themes/cncf-twenty-two/source/js/on-demand/modal.js
+++ b/web/wp-content/themes/cncf-twenty-two/source/js/on-demand/modal.js
@@ -22,6 +22,10 @@
 		let $modals = $( '.js-modal' ),
 		$body       = $( 'body' );
 
+		if ( 0 === $modals.length ) {
+			return;
+		}
+
 		$modals.each(
 			function( index_to_expand ) {
 				let $this     = $( this ),


### PR DESCRIPTION
Fixes #545

[Demo blog post with a variety of code blocks
](https://pr-549-cncfci.pantheonsite.io/blog/2022/05/22/code-block-test/)
The only use of modals on blog post pages is the wechat popup in the footer and that is causing some of the code blocks not to be highlighted. Instead of using that popup we could just link to a cncf.io/wechat page that shows the QR code. Likely this link gets hardly used anyway so this should be an acceptable user experience. That will then allow us to turn off the modal code on most pages of the site. I've updated the modal js so that it won't do it's dom-wrapping on pages that don't actually have a popup.