### PR TITLE
Override default cache headers to protect against DDOS

### DIFF
--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -600,11 +600,4 @@ class Lf_Mu_Admin {
 		$controller = new LF_MU_REST_Controller();
 		$controller->register_routes();
 	}
-
-	/**
-	 * Overrides the default cache headers.
-	 */
-	public function add_header_cache() {
-		header( 'Cache-Control: public, max-age=600, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
-	}
 }

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -600,4 +600,11 @@ class Lf_Mu_Admin {
 		$controller = new LF_MU_REST_Controller();
 		$controller->register_routes();
 	}
+
+	/**
+	 * Overrides the default cache headers.
+	 */
+	public function add_header_cache() {
+		header( 'Cache-Control: public, max-age=600, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
+	}
 }

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
@@ -166,6 +166,7 @@ class Lf_Mu {
 		$this->loader->add_action( 'admin_head', $plugin_admin, 'change_adminbar_colors' );
 		$this->loader->add_action( 'wp_head', $plugin_admin, 'change_adminbar_colors' );
 		$this->loader->add_action( 'rest_api_init', $plugin_admin, 'register_lf_rest_routes' );
+		$this->loader->add_action( 'send_headers', $plugin_admin, 'add_header_cache', 15 );
 
 		// Hook to save year in a meta fields for filtering.
 		$this->loader->add_action( 'save_post_lf_case_study', $plugin_admin, 'set_case_study_year', 10, 3 );

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
@@ -166,7 +166,6 @@ class Lf_Mu {
 		$this->loader->add_action( 'admin_head', $plugin_admin, 'change_adminbar_colors' );
 		$this->loader->add_action( 'wp_head', $plugin_admin, 'change_adminbar_colors' );
 		$this->loader->add_action( 'rest_api_init', $plugin_admin, 'register_lf_rest_routes' );
-		$this->loader->add_action( 'send_headers', $plugin_admin, 'add_header_cache', 15 );
 
 		// Hook to save year in a meta fields for filtering.
 		$this->loader->add_action( 'save_post_lf_case_study', $plugin_admin, 'set_case_study_year', 10, 3 );
@@ -251,6 +250,7 @@ class Lf_Mu {
 		$this->loader->add_filter( 'pre_get_posts', $plugin_public, 'remove_news_from_rss' );
 		$this->loader->add_filter( 'the_seo_framework_sitemap_nhpt_query_args', $plugin_public, 'remove_news_from_sitemap' );
 		$this->loader->add_filter( 'the_seo_framework_sitemap_supported_post_types', $plugin_public, 'remove_newsletters_from_sitemap' );
+		$this->loader->add_action( 'send_headers', $plugin_public, 'add_header_cache', 15 );
 	}
 
 	/**

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/public/class-lf-mu-public.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/public/class-lf-mu-public.php
@@ -324,4 +324,12 @@ class Lf_Mu_Public {
 		return array_diff( $post_types, $to_exclude );
 	}
 
+	/**
+	 * Overrides the default cache headers.
+	 */
+	public function add_header_cache() {
+		if ( ! is_admin() && ! is_user_logged_in() ) {
+			header( 'Cache-Control: public, max-age=600, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
+		}
+	}
 }

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/public/class-lf-mu-public.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/public/class-lf-mu-public.php
@@ -329,7 +329,7 @@ class Lf_Mu_Public {
 	 */
 	public function add_header_cache() {
 		if ( ! is_admin() && ! is_user_logged_in() ) {
-			header( 'Cache-Control: public, max-age=600, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
+			header( 'Cache-Control: public, max-age=60, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
 		}
 	}
 }


### PR DESCRIPTION
As per #729 

[PR dev instance](https://pr-733-cncfci.pantheonsite.io/)

Cache headers set when user is not logged in:
```
Cache-Control: public, max-age=60, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800
```

Since Pantheon cache gets cleared on a page-by-page basis when a page is updated, I have pushed `s-maxage` to half a day.

We should observe how the cache hit rate changes after merge and make sure all assets are being properly cached which they don't seem to be on these dev instances. Also we should re-run pagespeed.

Do before/after testing on all file types to make sure all of them are being cached properly.