### PR TITLE
Adding Store products to Project pages, #713

### DIFF
--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -224,6 +224,8 @@ class Lf_Mu_Admin {
 
 		$options['community_api_key'] = ( isset( $input['community_api_key'] ) && ! empty( $input['community_api_key'] ) ) ? esc_attr( $input['community_api_key'] ) : '';
 
+		$options['shopify_api_key'] = ( isset( $input['shopify_api_key'] ) && ! empty( $input['shopify_api_key'] ) ) ? esc_attr( $input['shopify_api_key'] ) : '';
+
 		$options['gtm_id'] = ( isset( $input['gtm_id'] ) && ! empty( $input['gtm_id'] ) ) ? esc_html( $input['gtm_id'] ) : '';
 
 		$options['promotion_image_id'] = ( isset( $input['promotion_image_id'] ) && ! empty( $input['promotion_image_id'] ) ) ? absint( $input['promotion_image_id'] ) : '';

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
@@ -96,6 +96,8 @@ if ( ! defined( 'WPINC' ) ) {
 
 		$community_api_key = ( isset( $options['community_api_key'] ) && ! empty( $options['community_api_key'] ) ) ? esc_attr( $options['community_api_key'] ) : '';
 
+		$shopify_api_key = ( isset( $options['shopify_api_key'] ) && ! empty( $options['shopify_api_key'] ) ) ? esc_attr( $options['shopify_api_key'] ) : '';
+
 		$gtm_id = ( isset( $options['gtm_id'] ) && ! empty( $options['gtm_id'] ) ) ? esc_attr( $options['gtm_id'] ) : '';
 
 		$promotion_image_id = ( isset( $options['promotion_image_id'] ) && ! empty( $options['promotion_image_id'] ) ) ? absint( $options['promotion_image_id'] ) : '';
@@ -732,6 +734,17 @@ if ( ! defined( 'WPINC' ) ) {
 							id="<?php echo esc_html( $this->plugin_name ); ?>-community_api_key"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[community_api_key]"
 							value="<?php echo esc_attr( $community_api_key ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="shopify_api_key">Shopify API
+							key</label>
+					</th>
+					<td>
+						<input type="text" class="shopify_api_key regular-text"
+							id="<?php echo esc_html( $this->plugin_name ); ?>-shopify_api_key"
+							name="<?php echo esc_html( $this->plugin_name ); ?>[shopify_api_key]"
+							value="<?php echo esc_attr( $shopify_api_key ); ?>" />
 					</td>
 				</tr>
 				<tr>

--- a/web/wp-content/themes/cncf-twenty-two/components/project-single.php
+++ b/web/wp-content/themes/cncf-twenty-two/components/project-single.php
@@ -260,39 +260,33 @@ endif;
 				</div>
 				<div class="wp-block-column is-vertically-aligned-bottom"
 					style="flex-basis:30%">
-					<p class="has-text-align-right is-style-link-cta"><a href="<?php echo esc_url( '/online-programs?_sft_lf-project=' . $project_slug ); ?>">See
-more recordings</a></p>
+					<p class="has-text-align-right is-style-link-cta"><a href="<?php echo esc_url( '/online-programs?_sft_lf-project=' . $project_slug ); ?>">See more recordings</a></p>
 				</div>
 			</div>
 			<div style="height:40px" aria-hidden="true"
 				class="wp-block-spacer is-style-20-40"></div>
-<!-- Embeded svg sprite reference -->
-<svg display="none" xmlns="http://www.w3.org/2000/svg">
-<symbol id="play-button" fill="none" viewBox="0 0 70 71" id=".5155955424562817" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_4409_15889)">
-<path d="M35 70.468c19.33 0 35-15.67 35-35s-15.67-35-35-35-35 15.67-35 35 15.67 35 35 35z" fill="#D62293"/>
-<path d="M26.676 51.298V18.964a2.682 2.682 0 0 1 4.394-2.06l19.367 16.177a2.686 2.686 0 0 1 0 4.115L31.07 53.362a2.676 2.676 0 0 1-4.394-2.064z" fill="#fff"/>
-</g>
-</symbol>
-</svg>
-
-			<div class="webinars columns-three">
+	<!-- Embeded svg sprite reference -->
+	<svg display="none" xmlns="http://www.w3.org/2000/svg">
+	<symbol id="play-button" fill="none" viewBox="0 0 70 71" id=".5155955424562817" xmlns="http://www.w3.org/2000/svg">
+	<g clip-path="url(#clip0_4409_15889)">
+	<path d="M35 70.468c19.33 0 35-15.67 35-35s-15.67-35-35-35-35 15.67-35 35 15.67 35 35 35z" fill="#D62293"/>
+	<path d="M26.676 51.298V18.964a2.682 2.682 0 0 1 4.394-2.06l19.367 16.177a2.686 2.686 0 0 1 0 4.115L31.07 53.362a2.676 2.676 0 0 1-4.394-2.064z" fill="#fff"/>
+	</g>
+	</symbol>
+	</svg>
+		<div class="webinars columns-three">
 				<?php
 				while ( $programs_query->have_posts() ) :
 					$programs_query->the_post();
-
 					get_template_part( 'components/webinar-recorded-item' );
-
-		endwhile;
+				endwhile;
 				?>
-
 			</div>
-			<div style="height:40px" aria-hidden="true"
-				class="wp-block-spacer is-style-20-40"></div>
+			<div style="height:40px" aria-hidden="true" class="wp-block-spacer is-style-20-40"></div>
+
 		</div>
 
-		<div style="height:120px" aria-hidden="true"
-			class="wp-block-spacer is-style-80-120"></div>
+		<div style="height:120px" aria-hidden="true" class="wp-block-spacer is-style-80-120"></div>
 
 			<?php
 			wp_reset_postdata();
@@ -326,8 +320,7 @@ endif;
 				<div class="wp-block-column is-vertically-aligned-bottom"
 					style="flex-basis:20%">
 					<p class="has-text-align-right is-style-link-cta"><a
-href="<?php echo esc_url( '/?post_type=post&s=' . $project_slug ); ?>">See
-all news</a></p>
+href="<?php echo esc_url( '/?post_type=post&s=' . $project_slug ); ?>">See all news</a></p>
 				</div>
 			</div>
 			<div style="height:40px" aria-hidden="true"
@@ -343,17 +336,18 @@ all news</a></p>
 				?>
 			</div>
 
-			<div style="height:40px" aria-hidden="true"
-				class="wp-block-spacer is-style-20-40"></div>
+			<div style="height:40px" aria-hidden="true"	class="wp-block-spacer is-style-20-40"></div>
 		</div>
 
-
-		<div style="height:120px" aria-hidden="true"
-			class="wp-block-spacer is-style-80-120"></div>
+		<div style="height:120px" aria-hidden="true" class="wp-block-spacer is-style-80-120"></div>
 
 			<?php
 			wp_reset_postdata();
 endif;
+		?>
+
+		<?php
+		echo do_shortcode( '[shopify_products project="' . $post->post_name . '"]' );
 		?>
 
 	</article>

--- a/web/wp-content/themes/cncf-twenty-two/components/project-single.php
+++ b/web/wp-content/themes/cncf-twenty-two/components/project-single.php
@@ -347,7 +347,7 @@ endif;
 		?>
 
 		<?php
-		echo do_shortcode( '[shopify_products project="' . $post->post_name . '"]' );
+		echo do_shortcode( '[shopify_products collection="' . $post->post_name . '"]' );
 		?>
 
 	</article>

--- a/web/wp-content/themes/cncf-twenty-two/functions.php
+++ b/web/wp-content/themes/cncf-twenty-two/functions.php
@@ -128,6 +128,7 @@ require_once 'includes/shortcodes/project-charts.php';
 require_once 'includes/shortcodes/radars.php';
 require_once 'includes/shortcodes/reports.php';
 require_once 'includes/shortcodes/selected-people.php';
+require_once 'includes/shortcodes/shopify-products.php';
 require_once 'includes/shortcodes/upcoming-webinars.php';
 require_once 'includes/shortcodes/youtube-playlist.php';
 

--- a/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
+++ b/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
@@ -6,7 +6,7 @@
  *
  * Usage:
  * [shopify_products]
- * [shopify_products project="tag-security" count=4]
+ * [shopify_products collection="tag-security" count=6]
  *
  * @package WordPress
  * @subpackage cncf-theme
@@ -23,9 +23,9 @@ function add_shopify_products_shortcode( $atts ) {
 	// Attributes.
 	$atts = shortcode_atts(
 		array(
-			'count'   => 3, // set default.
-			'project' => 'cncf', // set default.
-			'title'   => '',
+			'count'      => 3, // set default.
+			'collection' => 'cncf', // set default.
+			'title'      => '',
 		),
 		$atts,
 		'shopify_products'
@@ -47,7 +47,7 @@ function add_shopify_products_shortcode( $atts ) {
 	}
 
 	$count           = intval( $atts['count'] );
-	$collection_slug = trim( $atts['project'] );
+	$collection_slug = trim( $atts['collection'] );
 	$title           = $atts['title'] ?? '';
 	$section_title   = $title ? $title : get_the_title();
 
@@ -124,6 +124,9 @@ function add_shopify_products_shortcode( $atts ) {
 		return;
 	}
 
+	$product_count = count( $actual_products );
+	$more_link = ( $product_count < $count ) ? $store_url : $store_url . '/collections/' . $collection_slug;
+
 	ob_start();
 	?>
 <section class="shopify-products">
@@ -135,7 +138,7 @@ function add_shopify_products_shortcode( $atts ) {
 			</div>
 			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:30%">
 				<p
-					class="has-text-align-right is-style-link-cta"><a href="<?php echo esc_url( 'https://store.cncf.io/collections/' . $collection_slug ); ?>">More Products</a></p>
+					class="has-text-align-right is-style-link-cta"><a href="<?php echo esc_url( $more_link ); ?>">More Products</a></p>
 			</div>
 		</div>
 

--- a/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
+++ b/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Shopify Products
+ *
+ * Displays items from a collection
+ *
+ * Usage:
+ * [shopify_products]
+ * [shopify_products project="tag-security" count=4]
+ *
+ * @package WordPress
+ * @subpackage cncf-theme
+ * @since 1.0.0
+ */
+
+/**
+ * Shopify Products shortcode.
+ *
+ * @param array $atts Attributes.
+ */
+function add_shopify_products_shortcode( $atts ) {
+
+	// Attributes.
+	$atts = shortcode_atts(
+		array(
+			'count'   => 3, // set default.
+			'project' => 'cncf', // set default.
+			'title'   => '',
+		),
+		$atts,
+		'shopify_products'
+	);
+
+	$shopify_url     = 'https://cncf-merchandise-store.myshopify.com';
+	$endpoint        = $shopify_url . '/api/2022-01/graphql.json';
+	$store_url       = 'https://store.cncf.io';
+	$gift_card_title = 'Gift Card';
+
+	$site_options = get_option( 'lf-mu' );
+	if ( isset( $site_options['shopify_api_key'] ) && $site_options['shopify_api_key'] ) {
+		$storefront_api_token = $site_options['shopify_api_key'];
+	} else {
+		if ( current_user_can( 'edit_posts' ) ) {
+			echo 'Requires Shopify API token to be set in Settings.';
+			return;
+		}
+	}
+
+	$count           = intval( $atts['count'] );
+	$collection_slug = trim( $atts['project'] );
+	$title           = $atts['title'] ?? '';
+	$section_title   = $title ? $title : get_the_title();
+
+	if ( ! is_int( $count ) || ! $storefront_api_token ) {
+		return;
+	}
+
+	$args = array(
+		'headers' => array(
+			'Content-Type'                      => 'application/json',
+			'X-Shopify-Storefront-Access-Token' => $storefront_api_token,
+		),
+		'body'    => wp_json_encode(
+			array(
+				'query' => '
+			{
+				collectionByHandle(handle: "' . $collection_slug . '") {
+					products(first: ' . $count . ') {
+						edges {
+							node {
+								title
+								handle
+								availableForSale
+								featuredImage {
+									originalSrc
+									small: transformedSrc(maxWidth: 480, scale: 1)
+									medium: transformedSrc(maxWidth: 768, scale: 1)
+									large: transformedSrc(maxWidth: 1024, scale: 1)
+								}
+								variants(first: 1) {
+									edges {
+										node {
+											priceV2 {
+												amount
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			',
+			)
+		),
+	);
+
+	$response = wp_remote_post( $endpoint, $args );
+
+	if ( is_wp_error( $response ) ) {
+		error_log( $response->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		return;
+	}
+
+	$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+	if ( ! isset( $data['data']['collectionByHandle'] ) || null === $data['data']['collectionByHandle'] ) {
+		error_log( 'Collection not found or an error occurred.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		return;
+	}
+
+	$products = $data['data']['collectionByHandle']['products']['edges'] ?? '';
+
+	if ( ! $products || empty( $products ) ) {
+		return;
+	}
+
+	$actual_products = array_filter(
+		$products,
+		function( $product ) use ( $gift_card_title ) {
+			return $product['node']['title'] !== $gift_card_title && $product['node']['availableForSale'];
+		}
+	);
+
+	// If only Gift Card is available or no products available, return.
+	if ( empty( $actual_products ) ) {
+		return;
+	}
+
+	ob_start();
+	?>
+<section class="shopify-products">
+	<!-- see all  -->
+	<div class="wp-block-group is-style-no-padding is-style-see-all">
+		<div class="wp-block-columns are-vertically-aligned-bottom">
+			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:70%">
+				<h3 class="is-style-section-heading"><?php echo esc_html( $section_title ); ?> in CNCF Store</h3>
+			</div>
+			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:30%">
+				<p
+					class="has-text-align-right is-style-link-cta"><a href="<?php echo esc_url( 'https://store.cncf.io/collections/' . $collection_slug ); ?>">More Products</a></p>
+			</div>
+		</div>
+
+		<div style="height:40px" aria-hidden="true" class="wp-block-spacer is-style-20-40"></div>
+
+		<div class="products columns-four">
+
+			<?php
+			foreach ( $actual_products as $product ) :
+
+					$product_slug  = $product['node']['handle'] ?? '';
+					$product_link  = $store_url . '/products/' . $product_slug;
+					$product_title = $product['node']['title'] ?? '';
+					$price_amount  = $product['node']['variants']['edges'][0]['node']['priceV2']['amount'] ?? '';
+					$product_price = $price_amount ? '$' . number_format( $price_amount, 2, '.', '' ) : '';
+					$img_original  = $product['node']['featuredImage']['originalSrc'];
+					$img_480       = $product['node']['featuredImage']['small'];
+					$img_768       = $product['node']['featuredImage']['medium'];
+					$img_1024      = $product['node']['featuredImage']['large'];
+				?>
+			<div class="product-item has-animation-scale-2">
+				<a href="<?php echo esc_url( $product_link ); ?>" class="product-item__link" title="Buy <?php echo esc_attr( $product_title ); ?> in CNCF Store">
+					<div class="product-item__image">
+					<img src="<?php echo esc_url( $img_original ); ?>"
+						srcset="<?php echo esc_url( $img_480 ); ?> 480w, <?php echo esc_url( $img_768 ); ?> 768w, <?php echo esc_url( $img_1024 ); ?> 1024w"
+						sizes="(max-width: 480px) 480px, (max-width: 768px) 768px, 1024px" width="388" height="204" loading="lazy"
+						decoding="async"
+						alt="<?php echo esc_attr( $product_title ); ?>">
+					</div>
+					<h3 class="product-item__title">
+						<?php echo esc_html( $product_title ); ?></h3>
+				</a>
+				<span class="product-item__price"><?php echo esc_html( $product_price ); ?></span>
+			</div>
+					<?php
+			endforeach;
+			?>
+	</div>
+</div>
+<div style="height:80px;" aria-hidden="true" class="wp-block-spacer is-style-40-80"></div>
+</section>
+		<?php
+		$block_content = ob_get_clean();
+		return $block_content;
+}
+	add_shortcode( 'shopify_products', 'add_shopify_products_shortcode' );

--- a/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
+++ b/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
@@ -51,10 +51,6 @@ function add_shopify_products_shortcode( $atts ) {
 	$title           = $atts['title'] ?? '';
 	$section_title   = $title ? $title : get_the_title();
 
-	if ( ! is_int( $count ) || ! $storefront_api_token ) {
-		return;
-	}
-
 	$args = array(
 		'headers' => array(
 			'Content-Type'                      => 'application/json',

--- a/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
+++ b/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
@@ -42,8 +42,8 @@ function add_shopify_products_shortcode( $atts ) {
 	} else {
 		if ( current_user_can( 'edit_posts' ) ) {
 			echo 'Requires Shopify API token to be set in Settings.';
-			return;
 		}
+		return;
 	}
 
 	$count           = intval( $atts['count'] );

--- a/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
+++ b/web/wp-content/themes/cncf-twenty-two/includes/shortcodes/shopify-products.php
@@ -114,7 +114,7 @@ function add_shopify_products_shortcode( $atts ) {
 
 	$actual_products = array_filter(
 		$products,
-		function( $product ) use ( $gift_card_title ) {
+		function ( $product ) use ( $gift_card_title ) {
 			return $product['node']['title'] !== $gift_card_title && $product['node']['availableForSale'];
 		}
 	);
@@ -125,7 +125,7 @@ function add_shopify_products_shortcode( $atts ) {
 	}
 
 	$product_count = count( $actual_products );
-	$more_link = ( $product_count < $count ) ? $store_url : $store_url . '/collections/' . $collection_slug;
+	$more_link     = ( $product_count < $count ) ? $store_url : $store_url . '/collections/' . $collection_slug;
 
 	ob_start();
 	?>

--- a/web/wp-content/themes/cncf-twenty-two/source/scss/components/_products.scss
+++ b/web/wp-content/themes/cncf-twenty-two/source/scss/components/_products.scss
@@ -1,0 +1,61 @@
+.products {
+	display: grid;
+	grid-column-gap: $grid-column-gap;
+	grid-row-gap: $grid-row-gap;
+	grid-template-columns: repeat(auto-fit, minmax(250px, 350px));
+	@media (min-width: 1000px) {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.product-item {
+	background-color: $white;
+	font-weight: 700;
+	box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+	display: flex;
+	flex-direction: column;
+	border-radius: 3px;
+	&__link {
+		color: $black;
+	}
+	&__link:hover {
+		text-decoration: none;
+	}
+	&__image {
+		display: flex;
+		background-color: #f6f5f5;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+		height: 240px;
+		max-height: 240px;
+		@media (min-width: 1200px) {
+			height: 290px;
+			max-height: 290px;
+		}
+		img {
+			margin-left: auto;
+			margin-right: auto;
+			width: 100%;
+			max-height: 98%; // images have white space surround.
+			max-width: 98%; // images have white space surround.
+			object-fit: contain;
+		}
+	}
+	&__title {
+		font-size: 20px;
+		line-height: 140%;
+		padding-top: 25px;
+		padding-right: 25px;
+		margin-bottom: 10px;
+		padding-left: 25px;
+	}
+	&__price {
+		font-size: 12px;
+		line-height: 140%;
+		color: $gray-700;
+		margin-top: auto;
+		padding-left: 25px;
+		padding-bottom: 25px;
+		padding-right: 40px;
+	}
+}

--- a/web/wp-content/themes/cncf-twenty-two/source/scss/components/_projects.scss
+++ b/web/wp-content/themes/cncf-twenty-two/source/scss/components/_projects.scss
@@ -83,6 +83,9 @@
 			@media (min-width: 1000px) {
 				flex-direction: row;
 				align-items: center;
+				.wp-block-button__link {
+					white-space: nowrap;
+				}
 			}
 		}
 		&__icons {

--- a/web/wp-content/themes/cncf-twenty-two/source/scss/styles.scss
+++ b/web/wp-content/themes/cncf-twenty-two/source/scss/styles.scss
@@ -26,6 +26,7 @@
 @import 'components/newsletter';
 @import 'components/pagination';
 @import 'components/people';
+@import 'components/products';
 @import 'components/map';
 @import 'components/posts';
 @import 'components/post-author';


### PR DESCRIPTION
This adds Products related to the Project from the CNCF store to the projects page.

[Example Project page](https://pr-799-cncfci.pantheonsite.io/projects/kubernetes/)

![Screenshot-2023-10-07 --00 49 14](https://github.com/cncf/cncf.io/assets/10615884/dac8e123-5023-4977-bd1c-0d6ce0b58370)

- Mostly only 1 product per project is currently available (a sticker)
- Only Kubernetes seems to have two items / T-Shirts
- Some projects have nothing in stock (Prometheus)
- Some Incubated projects are simply not present in the store - CubeFS, Emissary Ingress, Keycloak, Kubeflow, etc

Questions
1) As only 1 product is often displayed in these sections, the "More Products" link doesn't show more products (as it links to the projects collection on the Store). To stop this, we could instead link to the Store index which would drive traffic generally across the store and perhaps make more sense. 
