### PR TITLE
Hello Bar Syndication

### DIFF
--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -675,9 +675,50 @@ class Lf_Mu_Admin {
             letter-spacing: 0.24px;
             line-height: 1.15;
             opacity: 0;
+            z-index: 9999;
+            transition: opacity 0.5s ease;
         ';
         hB.innerHTML = `{$hello_bar_content}`;
+
         document.body.insertBefore(hB, document.body.firstChild);
+
+        var fixedNav = document.querySelector('.td-navbar');
+
+        var isNavFixed = function() {
+            return window.getComputedStyle(fixedNav).position === 'fixed';
+        };
+
+        var updateNavPosition = function() {
+            if (!fixedNav) return;
+
+            if (isNavFixed()) {
+                var hBHeight = hB.offsetHeight;
+                fixedNav.style.top = hBHeight + 'px';
+                window.addEventListener('scroll', function() {
+                    if (isNavFixed()) {
+                        if (window.scrollY >= hBHeight) {
+                            fixedNav.style.top = '0';
+                        } else {
+                            fixedNav.style.top = hBHeight + 'px';
+                        }
+                    }
+                });
+            } else {
+                fixedNav.style.top = '0';
+            }
+        };
+
+        var resizeObserver = new ResizeObserver(function() {
+            updateNavPosition();
+        });
+
+        resizeObserver.observe(hB);
+
+        window.addEventListener('resize', function() {
+            updateNavPosition();
+        });
+
+        updateNavPosition();
 
         var style = document.createElement('style');
         style.innerHTML = `
@@ -688,16 +729,19 @@ class Lf_Mu_Admin {
                 text-underline-position: under;
                 transition: all 0.1s ease;
             }
-            .cncf-hello-bar a:hover {
+            .cncf-hello-bar a:hover, .cncf-hello-bar a:focus {
                 text-decoration: none;
                 text-underline-position: unset;
             }
         `;
         document.head.appendChild(style);
-		hB.style.opacity = '1';
-	});
+
+        setTimeout(function() {
+            hB.style.opacity = '1';
+        }, 5);
+    });
 })();
-		";
+";
 
 		$js_content = $this->minify_js( $js_content );
 

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -678,7 +678,10 @@ class Lf_Mu_Admin {
             z-index: 9999;
             transition: opacity 0.5s ease;
         ';
-        hB.innerHTML = `{$hello_bar_content}`;
+
+		const subdomain = window.location.hostname.split('.')[0];
+		const hbContent = `{$hello_bar_content}`;
+		hB.innerHTML = hbContent.replace(/utm_source=www/g, 'utm_source=' + subdomain );
 
         document.body.insertBefore(hB, document.body.firstChild);
 

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -679,9 +679,9 @@ class Lf_Mu_Admin {
             transition: opacity 0.5s ease;
         ';
 
-		const subdomain = window.location.hostname.split('.')[0];
-		const hbContent = `{$hello_bar_content}`;
-		hB.innerHTML = hbContent.replace(/utm_source=www/g, 'utm_source=' + subdomain );
+        const subdomain = window.location.hostname.split('.')[0];
+        const hbContent = `{$hello_bar_content}`;
+        hB.innerHTML = hbContent.replace(/utm_source=www/g, 'utm_source=' + subdomain );
 
         document.body.insertBefore(hB, document.body.firstChild);
 
@@ -696,13 +696,13 @@ class Lf_Mu_Admin {
 
             if (isNavFixed()) {
                 var hBHeight = hB.offsetHeight;
-				if (window.scrollY > 0 && window.scrollY < hBHeight) {
-						fixedNav.style.top = hBHeight - window.scrollY + 'px';
-					} else if (window.scrollY > hBHeight) {
-						fixedNav.style.top = '0';
-					} else {
-					fixedNav.style.top = hBHeight + 'px';
-				}
+                if (window.scrollY > 0 && window.scrollY < hBHeight) {
+                        fixedNav.style.top = hBHeight - window.scrollY + 'px';
+                    } else if (window.scrollY > hBHeight) {
+                        fixedNav.style.top = '0';
+                    } else {
+                    fixedNav.style.top = hBHeight + 'px';
+                }
             } else {
                 fixedNav.style.top = '0';
             }
@@ -714,13 +714,8 @@ class Lf_Mu_Admin {
 
         resizeObserver.observe(hB);
 
-        window.addEventListener('resize', function() {
-            updateNavPosition();
-        });
-
-		window.addEventListener('scroll', function() {
-            updateNavPosition();
-        });
+        window.addEventListener('resize', () => updateNavPosition());
+        window.addEventListener('scroll', () => updateNavPosition());
 
         updateNavPosition();
 

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/class-lf-mu-admin.php
@@ -693,16 +693,13 @@ class Lf_Mu_Admin {
 
             if (isNavFixed()) {
                 var hBHeight = hB.offsetHeight;
-                fixedNav.style.top = hBHeight + 'px';
-                window.addEventListener('scroll', function() {
-                    if (isNavFixed()) {
-                        if (window.scrollY >= hBHeight) {
-                            fixedNav.style.top = '0';
-                        } else {
-                            fixedNav.style.top = hBHeight + 'px';
-                        }
-                    }
-                });
+				if (window.scrollY > 0 && window.scrollY < hBHeight) {
+						fixedNav.style.top = hBHeight - window.scrollY + 'px';
+					} else if (window.scrollY > hBHeight) {
+						fixedNav.style.top = '0';
+					} else {
+					fixedNav.style.top = hBHeight + 'px';
+				}
             } else {
                 fixedNav.style.top = '0';
             }
@@ -715,6 +712,10 @@ class Lf_Mu_Admin {
         resizeObserver.observe(hB);
 
         window.addEventListener('resize', function() {
+            updateNavPosition();
+        });
+
+		window.addEventListener('scroll', function() {
             updateNavPosition();
         });
 

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
@@ -36,6 +36,10 @@ if ( ! defined( 'WPINC' ) ) {
 
 		$hello_bar_text = ( isset( $options['hello_bar_text'] ) && ! empty( $options['hello_bar_text'] ) ) ? esc_attr( $options['hello_bar_text'] ) : '';
 
+		$upload_dir             = wp_upload_dir();
+		$hello_bar_js_file_path = $upload_dir['basedir'] . '/hello-bar.js';
+		$hello_bar_js_file_url  = $upload_dir['baseurl'] . '/hello-bar.js';
+
 		$header_image_id = ( isset( $options['header_image_id'] ) && ! empty( $options['header_image_id'] ) ) ? absint( $options['header_image_id'] ) : '';
 
 		$header_cta_text = ( isset( $options['header_cta_text'] ) && ! empty( $options['header_cta_text'] ) ) ? esc_attr( $options['header_cta_text'] ) : '';
@@ -189,6 +193,28 @@ if ( ! defined( 'WPINC' ) ) {
 								data-default-color="#0175E4"
 								value="<?php echo esc_attr( $hello_bar_bg ); ?>" />
 						</div>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">
+						<label for="hello_bar_syndication">Hello Bar
+							Syndication</label>
+					</th>
+					<td colspan="2">
+
+						<?php
+						if ( $hello_bar_js_file_path ) {
+							?>
+						<p
+							style="margin-bottom: 5px;">Use the below script on your websites to embed the Hello Bar.</p>
+						<input type="text" disabled style="width:100%;"
+							name="hello-bar-url"
+							value='<script src="<?php echo esc_attr( $hello_bar_js_file_url ); ?>"></script>' /> <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
+						<p
+							style="margin-top: 5px;">Note: A <i>change</i> to the Hello Bar settings is required to regenerate the JS file. To hide the Hello Bar on syndicated sites, choose to not Show the Hello Bar.</p>
+							<?php
+						}
+						?>
 					</td>
 				</tr>
 			</tbody>
@@ -509,7 +535,8 @@ if ( ! defined( 'WPINC' ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="social_twitter">X (formerly Twitter)</label>
+					<th scope="row"><label for="social_twitter">X (formerly
+							Twitter)</label>
 					</th>
 					<td>
 						<input type="text" class="social_twitter regular-text"
@@ -606,12 +633,12 @@ if ( ! defined( 'WPINC' ) ) {
 							CTA Link</label>
 					</th>
 					<td>
-					<input type="text"
+						<input type="text"
 							class="promotion_cta_link regular-text"
 							id="<?php echo esc_html( $this->plugin_name ); ?>-promotion_cta_link"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[promotion_cta_link]"
 							value="<?php echo esc_url( $promotion_cta_link ); ?>"
-							placeholder="https://training.linuxfoundation.org/cyber-monday-cncf-2023/" />						
+							placeholder="https://training.linuxfoundation.org/cyber-monday-cncf-2023/" />
 					</td>
 				</tr>
 			</tbody>
@@ -688,12 +715,12 @@ if ( ! defined( 'WPINC' ) ) {
 							CTA Link</label>
 					</th>
 					<td>
-					<input type="text"
+						<input type="text"
 							class="promotion_cta_link2 regular-text"
 							id="<?php echo esc_html( $this->plugin_name ); ?>-promotion_cta_link2"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[promotion_cta_link2]"
 							value="<?php echo esc_url( $promotion_cta_link2 ); ?>"
-							placeholder="https://training.linuxfoundation.org/cyber-monday-cncf-2023/" />						
+							placeholder="https://training.linuxfoundation.org/cyber-monday-cncf-2023/" />
 					</td>
 				</tr>
 			</tbody>
@@ -789,33 +816,39 @@ if ( ! defined( 'WPINC' ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="google_maps_api_key">Google Maps API
+					<th scope="row"><label for="google_maps_api_key">Google Maps
+							API
 							key for geocoding</label>
 					</th>
 					<td>
-						<input type="text" class="google_maps_api_key regular-text"
+						<input type="text"
+							class="google_maps_api_key regular-text"
 							id="<?php echo esc_html( $this->plugin_name ); ?>-google_maps_api_key"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[google_maps_api_key]"
 							value="<?php echo esc_attr( $google_maps_api_key ); ?>" />
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="google_maps_api_public_key">Google Maps API
+					<th scope="row"><label
+							for="google_maps_api_public_key">Google Maps API
 							key for public map js</label>
 					</th>
 					<td>
-						<input type="text" class="google_maps_api_public_key regular-text"
+						<input type="text"
+							class="google_maps_api_public_key regular-text"
 							id="<?php echo esc_html( $this->plugin_name ); ?>-google_maps_api_public_key"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[google_maps_api_public_key]"
 							value="<?php echo esc_attr( $google_maps_api_public_key ); ?>" />
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="community_api_key">Community Site API
+					<th scope="row"><label for="community_api_key">Community
+							Site API
 							key</label>
 					</th>
 					<td>
-						<input type="text" class="community_api_key regular-text"
+						<input type="text"
+							class="community_api_key regular-text"
 							id="<?php echo esc_html( $this->plugin_name ); ?>-community_api_key"
 							name="<?php echo esc_html( $this->plugin_name ); ?>[community_api_key]"
 							value="<?php echo esc_attr( $community_api_key ); ?>" />

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/lf-mu-admin-display.php
@@ -209,7 +209,7 @@ if ( ! defined( 'WPINC' ) ) {
 							style="margin-bottom: 5px;">Use the below script on your websites to embed the Hello Bar.</p>
 						<input type="text" disabled style="width:100%;"
 							name="hello-bar-url"
-							value='<script src="<?php echo esc_attr( $hello_bar_js_file_url ); ?>"></script>' /> <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
+							value='<script defer src="<?php echo esc_attr( $hello_bar_js_file_url ); ?>"></script>' /> <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
 						<p
 							style="margin-top: 5px;">Note: A <i>change</i> to the Hello Bar settings is required to regenerate the JS file. To hide the Hello Bar on syndicated sites, choose to not Show the Hello Bar.</p>
 							<?php

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/sync-ktps.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/sync-ktps.php
@@ -86,9 +86,9 @@ foreach ( $ktps as $ktp ) {
 // delete any KTP posts which aren't in $synced_ids.
 $query = new WP_Query(
 	array(
-		'post_type'    => 'lf_ktp',
-		'post__not_in' => $synced_ids,
-		'posts_per_page'  => -1,
+		'post_type'      => 'lf_ktp',
+		'post__not_in'   => $synced_ids,
+		'posts_per_page' => -1,
 	)
 );
 while ( $query->have_posts() ) {

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/sync-people.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/admin/partials/sync-people.php
@@ -146,10 +146,10 @@ foreach ( $people as $p ) {
 	}
 
 	$args = array(
-		'post_type'              => 'lf_person',
-		'title'                  => $p->name,
-		'post_status'            => 'publish',
-		'numberposts'            => 1,
+		'post_type'   => 'lf_person',
+		'title'       => $p->name,
+		'post_status' => 'publish',
+		'numberposts' => 1,
 	);
 
 	if ( $image_url ) {
@@ -203,9 +203,9 @@ foreach ( $people as $p ) {
 // delete any People posts which aren't in $synced_ids.
 $query = new WP_Query(
 	array(
-		'post_type'    => 'lf_person',
-		'post__not_in' => $synced_ids,
-		'posts_per_page'  => -1,
+		'post_type'      => 'lf_person',
+		'post__not_in'   => $synced_ids,
+		'posts_per_page' => -1,
 	)
 );
 while ( $query->have_posts() ) {

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu-rest-controller.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu-rest-controller.php
@@ -79,22 +79,4 @@ class LF_MU_REST_Controller extends WP_REST_Controller {
 
 		return new WP_REST_Response( array( 'Success' ), 200 );
 	}
-
-	/**
-	 * Get hello bar data.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
-	 */
-	public function get_hello( $request ) {
-		$items = array();
-
-		$options                    = get_option( 'lf-mu' );
-		$items['show_hello_bar']    = ( isset( $options['show_hello_bar'] ) && ! empty( $options['show_hello_bar'] ) ) ? 1 : 0;
-		$items['hello_bar_content'] = ( isset( $options['hello_bar_content'] ) && ! empty( $options['hello_bar_content'] ) ) ? $options['hello_bar_content'] : '';
-		$items['hello_bar_bg']      = ( isset( $options['hello_bar_bg'] ) && ! empty( $options['hello_bar_bg'] ) ) ? esc_attr( $options['hello_bar_bg'] ) : '';
-		$items['hello_bar_text']    = ( isset( $options['hello_bar_text'] ) && ! empty( $options['hello_bar_text'] ) ) ? esc_attr( $options['hello_bar_text'] ) : '';
-
-		return new WP_REST_Response( $items, 200 );
-	}
 }

--- a/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
+++ b/web/wp-content/mu-plugins/wp-mu-plugins/lf-mu/includes/class-lf-mu.php
@@ -223,6 +223,8 @@ class Lf_Mu {
 		$this->loader->add_filter( 'pre_get_posts', $plugin_admin, 'set_events_admin_order' );
 
 		$this->loader->add_filter( 'ppp_nonce_life', $plugin_admin, 'set_post_preview_expiry' );
+
+		$this->loader->add_action( 'update_option_lf-mu', $plugin_admin, 'generate_hello_bar_js', 10, 3 );
 	}
 
 	/**

--- a/web/wp-content/themes/cncf-twenty-two/classes/class-lf-utils.php
+++ b/web/wp-content/themes/cncf-twenty-two/classes/class-lf-utils.php
@@ -661,8 +661,8 @@ class LF_Utils {
 		$query = new WP_Query( $args );
 		while ( $query->have_posts() ) {
 			$query->the_post();
-			$person_title        = $post->post_title;
-			$person_image_url    = wp_get_attachment_image_src( get_post_meta( get_the_ID(), 'lf_human_image', true ), 'newsroom-post-width' )[0];
+			$person_title     = $post->post_title;
+			$person_image_url = wp_get_attachment_image_src( get_post_meta( get_the_ID(), 'lf_human_image', true ), 'newsroom-post-width' )[0];
 
 			$person_profile_link = get_post_meta( get_the_ID(), 'lf_human_post_url', true );
 			if ( ! $person_profile_link ) {


### PR DESCRIPTION
![Screenshot-2024-09-20 --16 12 07](https://github.com/user-attachments/assets/c29859bb-7365-4e3b-96c9-dadb8a837a7a)

- The hello bar JS file is generated/updated when Hello Bar settings are updated in Settings. Any change to the content or the function needs to have the Settings saved again to regenerate the latest version of the file.
- My thinking was that we could keep the Hello Bar embed on microsite, as the Show option will turn it on or off (it blanks the JS file). Pondered over this approach but figured it would work. 
- The JS file generated and put in to uploads:
```
https://pr-886-cncfci.pantheonsite.io/wp-content/uploads/hello-bar.js
```

Above script is [implemented on Glossary preview](https://deploy-preview-3315--cncfglossary.netlify.app) site via [this PR](https://github.com/cncf/glossary/pull/3315)

Outstanding:
- UTM tracking question
- Might have to remove or dynamically include z-index on the banner (need to test with menu on Jobs site/Shop)