### PR TITLE
#773 Fix menu overflow on smaller screens

### DIFF
--- a/web/wp-content/themes/cncf-twenty-two/source/scss/core/_header.scss
+++ b/web/wp-content/themes/cncf-twenty-two/source/scss/core/_header.scss
@@ -585,9 +585,11 @@
 	padding: 7px 7px;
 	font-family: $font-primary;
 	&__image-wrapper {
-		width: 194px;
-		height: 102px;
-		flex-shrink: 0;
+		flex: 0 0 140px;
+		height: auto;
+		@media screen and (min-width: 360px) {
+			flex: 0 0 194px;
+		}
 	}
 	&__link {
 		display: block;
@@ -598,6 +600,9 @@
 		width: 100%;
 		object-fit: cover;
 		border-radius: 3px;
+		@media screen and (max-width: 359px) {
+			object-position: left;
+		}
 	}
 	&__text-wrapper {
 		padding-left: 20px;


### PR DESCRIPTION
This fixes the menu overflowing on smaller screens, 

Instead of making the image smaller, we crop the size slightly and position the image to the left. This is a better experience than the whole menu having some white space at the edge of it, or reducing/removing text from the menu item.

![Screenshot-2024-12-29 --14 25 58@2x](https://github.com/user-attachments/assets/50a991fd-1d5d-4932-a049-75006266b293)
