### PR TITLE
ci(build_test_and_deploy): pin contents: read on the default token

### DIFF
--- a/.github/workflows/build_test_and_deploy.yml
+++ b/.github/workflows/build_test_and_deploy.yml
@@ -25,6 +25,14 @@ env:
   CI_PROJECT_NAME: ${{ github.repository }}
   DEFAULT_BRANCH: "main"
 
+# The default GITHUB_TOKEN is only used for read-only GET calls to
+# api.github.com/repos/*/pulls/* and /repos/*/commits/*/pulls.
+# The "add commit comment" path (scripts/github/add-commit-comment) reads
+# the token from `composer config --global github-oauth.github.com`, not
+# from the workflow's GITHUB_TOKEN. Terminus / Pantheon deploys use
+# TERMINUS_TOKEN + SSH_PRIVATE_KEY.
+permissions:
+  contents: read
 
 jobs:
   configure_env_vars:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the only workflow here.

The workflow uses `${{ github.token }}` only for read-only GET calls against `api.github.com/repos/*/pulls/*` and `/repos/*/commits/*/pulls` to look up PR metadata. The actual writes happen elsewhere with dedicated secrets:
- Commit comments: `scripts/github/add-commit-comment` reads its token from `composer config --global github-oauth.github.com`, not from the workflow's `GITHUB_TOKEN`.
- Pantheon multidev deploys: `TERMINUS_TOKEN` + `SSH_PRIVATE_KEY`.

An inline comment was added explaining the chosen scope. YAML validated locally.